### PR TITLE
Edit ControlCommand's SetOrder method

### DIFF
--- a/CodingConnected.TraCI.NET/Commands/ControlCommands.cs
+++ b/CodingConnected.TraCI.NET/Commands/ControlCommands.cs
@@ -224,7 +224,7 @@ namespace CodingConnected.TraCI.NET.Commands
 		{
 			var command = new TraCICommand
 			{
-				Identifier = TraCIConstants.CMD_GETVERSION, 
+				Identifier = TraCIConstants.CMD_SETORDER, 
 				Contents = BitConverter.GetBytes(index).Reverse().ToArray()
 			};
 			var response = Client.SendMessage(command);


### PR DESCRIPTION
In SetOrder() method's   identifier  CMD_GETVERSION was used which needs to be replaced with CMD_SETORDER to set the order of multiple Clients