### PR TITLE
Fix GetCommand function with byte value

### DIFF
--- a/CodingConnected.TraCI.NET/Helpers/TraCICommandHelper.cs
+++ b/CodingConnected.TraCI.NET/Helpers/TraCICommandHelper.cs
@@ -408,7 +408,7 @@ namespace CodingConnected.TraCI.NET.Helpers
             var bytes = new List<byte> { messageType };
             bytes.AddRange(TraCIDataConverter.GetTraCIBytesFromASCIIString(id));
             bytes.Add(TraCIConstants.TYPE_BYTE);
-            bytes.AddRange(TraCIDataConverter.GetTraCIBytesFromByte(value));
+            bytes.Add(value);
             var command = new TraCICommand
             {
                 Identifier = commandType,


### PR DESCRIPTION
Since the type of value is byte, there's no need to convert value. And when running TraCIDataConverter.GetTraCIBytesFromByte(value), it will return a result with 2 bytes and then cause problems like Vehicle.Remove().